### PR TITLE
Minimal support for Echo and Request-tag [RFC 9175]

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ The following features are supported by the library:
     - Observing Resources in the Constrained Application Protocol [RFC 7641](https://tools.ietf.org/html/rfc7641)
     - Block-Wise Transfers in the Constrained Application Protocol [RFC 7959](https://tools.ietf.org/html/rfc7959)
     - PATCH and FETCH Methods [RFC 8132](https://tools.ietf.org/html/rfc8132)
+* Partial support for [RFC 9175](https://datatracker.ietf.org/doc/html/rfc9175)
+  - Request-Tag support for blockwise transfers
+  - Client side handling of echo challenge
 * CoRE Link Format processing API
     - Constrained RESTful Environments (CoRE) Link Format [RFC 6690](https://tools.ietf.org/html/rfc6690)
 * CoAP server mode

--- a/coap-cli/src/test/java/com/mbed/coap/cli/CoapCliTest.java
+++ b/coap-cli/src/test/java/com/mbed/coap/cli/CoapCliTest.java
@@ -109,10 +109,13 @@ class CoapCliTest {
         assertEquals("\nReceived 29\n", sw.toString().replace("\r", ""));
 
         CoapRequest expected = CoapRequest.post("/test")
-                .query("par1", "val1")
-                .payload(Opaque.of("{\"id\":\"22da5c828e9c4f10bc57\"}"), MediaTypes.CT_APPLICATION_JSON)
-                .block1Req(1, S_16, false)
-                .proxy("http://another-uri");
+                .options(it -> it
+                        .query("par1", "val1")
+                        .block1Req(1, S_16, false)
+                        .proxyUri("http://another-uri")
+                        .requestTag(sendCommand.request.options().getRequestTag()) // it's random
+                )
+                .payload(Opaque.of("{\"id\":\"22da5c828e9c4f10bc57\"}"), MediaTypes.CT_APPLICATION_JSON);
         assertEquals(expected, sendCommand.request);
     }
 

--- a/coap-core/src/main/java/com/mbed/coap/packet/CoapOptionsBuilder.java
+++ b/coap-core/src/main/java/com/mbed/coap/packet/CoapOptionsBuilder.java
@@ -16,6 +16,8 @@
 package com.mbed.coap.packet;
 
 import java.time.Duration;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 public class CoapOptionsBuilder {
     private final HeaderOptions options;
@@ -90,8 +92,20 @@ public class CoapOptionsBuilder {
         return this;
     }
 
+    public CoapOptionsBuilder unsetSize2Res() {
+        options.setSize2Res(null);
+        return this;
+    }
+
     public CoapOptionsBuilder block1Req(BlockOption block) {
         options.setBlock1Req(block);
+        return this;
+    }
+
+    public CoapOptionsBuilder ifNull(Function<HeaderOptions, Object> predicate, Consumer<CoapOptionsBuilder> command) {
+        if (predicate.apply(options) == null) {
+            command.accept(this);
+        }
         return this;
     }
 
@@ -177,6 +191,16 @@ public class CoapOptionsBuilder {
 
     public CoapOptionsBuilder proxyScheme(String scheme) {
         options.setProxyScheme(scheme);
+        return this;
+    }
+
+    public CoapOptionsBuilder echo(Opaque echo) {
+        options.setEcho(echo);
+        return this;
+    }
+
+    public CoapOptionsBuilder requestTag(Opaque requestTag) {
+        options.setRequestTag(requestTag);
         return this;
     }
 }

--- a/coap-core/src/main/java/com/mbed/coap/server/block/BlockRequestId.java
+++ b/coap-core/src/main/java/com/mbed/coap/server/block/BlockRequestId.java
@@ -16,6 +16,7 @@
  */
 package com.mbed.coap.server.block;
 
+import com.mbed.coap.packet.CoapRequest;
 import java.net.InetSocketAddress;
 import java.util.Objects;
 
@@ -24,7 +25,11 @@ class BlockRequestId {
     private final String uriPath;
     private final InetSocketAddress sourceAddress;
 
-    public BlockRequestId(String uriPath, InetSocketAddress sourceAddress) {
+    static BlockRequestId from(CoapRequest request) {
+        return new BlockRequestId(request.options().getUriPath(), request.getPeerAddress());
+    }
+
+    private BlockRequestId(String uriPath, InetSocketAddress sourceAddress) {
         this.uriPath = uriPath;
         this.sourceAddress = sourceAddress;
     }

--- a/coap-core/src/main/java/com/mbed/coap/server/block/BlockWiseCallback.java
+++ b/coap-core/src/main/java/com/mbed/coap/server/block/BlockWiseCallback.java
@@ -57,8 +57,7 @@ class BlockWiseCallback {
 
         if (request.getMethod() != null && csm.useBlockTransfer(requestPayload)) {
             //request that needs to use blocks
-            Opaque newPayload = BlockWiseTransfer.updateWithFirstBlock(request, csm);
-            this.request = request.payload(newPayload);
+            this.request = BlockWiseTransfer.createFirstBlock(request, csm);
             numberOfBertBlocks = csm.getBlockSize().numberOfBlocksPerMessage(csm.getMaxOutboundPayloadSize());
 
         } else {

--- a/coap-core/src/main/java/com/mbed/coap/server/block/BlockWiseIncomingTransaction.java
+++ b/coap-core/src/main/java/com/mbed/coap/server/block/BlockWiseIncomingTransaction.java
@@ -27,6 +27,7 @@ import com.mbed.coap.packet.Opaque;
 import com.mbed.coap.server.messaging.Capabilities;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,10 +37,12 @@ class BlockWiseIncomingTransaction {
     private final ByteArrayOutputStream payload;
     private final int maxIncomingBlockTransferSize;
     private final Capabilities csm;
+    private final Opaque requestTag;
 
     BlockWiseIncomingTransaction(CoapRequest request, int maxIncomingBlockTransferSize, Capabilities csm) {
         this.maxIncomingBlockTransferSize = maxIncomingBlockTransferSize;
         this.csm = csm;
+        this.requestTag = request.options().getRequestTag();
         Integer expectedPayloadSize = request.options().getSize1();
         BlockOption blockOption = request.options().getBlock1Req();
 
@@ -68,6 +71,10 @@ class BlockWiseIncomingTransaction {
             // should never happen
             throw new CoapCodeException(Code.C500_INTERNAL_SERVER_ERROR, e);
         }
+    }
+
+    boolean validateRequestTag(CoapRequest request) {
+        return Objects.equals(requestTag, request.options().getRequestTag());
     }
 
     Opaque getCombinedPayload() {

--- a/coap-core/src/main/java/com/mbed/coap/server/filter/EchoFilter.java
+++ b/coap-core/src/main/java/com/mbed/coap/server/filter/EchoFilter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022-2023 java-coap contributors (https://github.com/open-coap/java-coap)
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mbed.coap.server.filter;
+
+import com.mbed.coap.packet.CoapRequest;
+import com.mbed.coap.packet.CoapResponse;
+import com.mbed.coap.packet.Code;
+import com.mbed.coap.utils.Filter;
+import com.mbed.coap.utils.Service;
+import java.util.concurrent.CompletableFuture;
+
+public class EchoFilter implements Filter.SimpleFilter<CoapRequest, CoapResponse> {
+
+    @Override
+    public CompletableFuture<CoapResponse> apply(CoapRequest request, Service<CoapRequest, CoapResponse> service) {
+        return service
+                .apply(request)
+                .thenCompose(resp -> {
+                    if (resp.getCode() == Code.C401_UNAUTHORIZED && resp.options().getEcho() != null) {
+                        // server required freshness verification, retry with echo
+                        CoapRequest requestWithEcho = request.options(it -> it.echo(resp.options().getEcho()));
+                        return service.apply(requestWithEcho);
+                    } else {
+                        return resp.toFuture();
+                    }
+                });
+    }
+}

--- a/coap-core/src/main/java/com/mbed/coap/server/messaging/RequestTagSupplier.java
+++ b/coap-core/src/main/java/com/mbed/coap/server/messaging/RequestTagSupplier.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022-2023 java-coap contributors (https://github.com/open-coap/java-coap)
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mbed.coap.server.messaging;
+
+import com.mbed.coap.packet.Opaque;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@FunctionalInterface
+public interface RequestTagSupplier {
+    RequestTagSupplier NULL = () -> null;
+
+    Opaque next();
+
+    static RequestTagSupplier createSequential() {
+        return createSequential(new Random().nextInt(0xFFFF));
+    }
+
+    static RequestTagSupplier createSequential(int init) {
+        final AtomicInteger current = new AtomicInteger(init);
+
+        return () -> Opaque.variableUInt(current.incrementAndGet());
+    }
+}

--- a/coap-core/src/test/java/com/mbed/coap/packet/CoapOptionsBuilderTest.java
+++ b/coap-core/src/test/java/com/mbed/coap/packet/CoapOptionsBuilderTest.java
@@ -68,6 +68,8 @@ public class CoapOptionsBuilderTest {
                 .proxyScheme("http")
                 .locationPath("/location")
                 .locationQuery("par2=val2")
+                .echo(decodeHex("248618b4"))
+                .requestTag(decodeHex("da611128"))
                 .custom(1000, decodeHex("010203"))
                 .build();
 
@@ -90,6 +92,8 @@ public class CoapOptionsBuilderTest {
         expected.setProxyScheme("http");
         expected.setLocationPath("/location");
         expected.setLocationQuery("par2=val2");
+        expected.setEcho(decodeHex("248618b4"));
+        expected.setRequestTag(decodeHex("da611128"));
         expected.put(1000, decodeHex("010203"));
 
         assertEquals(expected, options);
@@ -101,14 +105,29 @@ public class CoapOptionsBuilderTest {
                 .observe(41)
                 .block2Res(2, BlockSize.S_256, false)
                 .block1Req(0, BlockSize.S_256, true)
+                .size2Res(535)
                 .build();
 
         HeaderOptions unsetOptions = CoapOptionsBuilder.from(options)
                 .unsetObserve()
                 .unsetBlock1Req()
                 .unsetBlock2Res()
+                .unsetSize2Res()
                 .build();
 
         assertEquals(new HeaderOptions(), unsetOptions);
+    }
+
+    @Test
+    void shouldRunWithIfCondition() {
+        CoapOptionsBuilder builder = options()
+                .ifNull(HeaderOptions::getAccept, o -> o.accept((short) 321));
+        assertEquals(321, builder.build().getAccept());
+
+        // when
+        builder.ifNull(HeaderOptions::getAccept, o -> o.accept((short) 43432));
+
+        // then, value not changed
+        assertEquals(321, builder.build().getAccept());
     }
 }

--- a/coap-core/src/test/java/com/mbed/coap/packet/HeaderOptionsTest.java
+++ b/coap-core/src/test/java/com/mbed/coap/packet/HeaderOptionsTest.java
@@ -19,6 +19,7 @@ package com.mbed.coap.packet;
 import static com.mbed.coap.packet.BasicHeaderOptions.hasNoCacheKey;
 import static com.mbed.coap.packet.BasicHeaderOptions.isCritical;
 import static com.mbed.coap.packet.BasicHeaderOptions.isUnsave;
+import static com.mbed.coap.packet.Opaque.decodeHex;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -40,7 +41,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 
-public class HeaderOptionTest {
+public class HeaderOptionsTest {
 
     @Test
     public void testEmpty() throws IOException, CoapException {
@@ -90,6 +91,8 @@ public class HeaderOptionTest {
         hdr.setUriHost("uri-host");
         hdr.setUriPort(5683);
         hdr.setUriQuery("par1=dupa&par2=dupa2");
+        hdr.setEcho(decodeHex("0102030405060708090a"));
+        hdr.setRequestTag(Opaque.of("tag-0001"));
         hdr.put(36, Opaque.variableUInt((1357)));
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/coap-core/src/test/java/com/mbed/coap/server/filter/EchoFilterTest.java
+++ b/coap-core/src/test/java/com/mbed/coap/server/filter/EchoFilterTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2022-2023 java-coap contributors (https://github.com/open-coap/java-coap)
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mbed.coap.server.filter;
+
+import static com.mbed.coap.packet.CoapRequest.post;
+import static com.mbed.coap.packet.CoapResponse.coapResponse;
+import static com.mbed.coap.packet.CoapResponse.ok;
+import static com.mbed.coap.packet.Code.C401_UNAUTHORIZED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import com.mbed.coap.packet.CoapRequest;
+import com.mbed.coap.packet.CoapResponse;
+import com.mbed.coap.packet.Opaque;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class EchoFilterTest {
+
+    private final EchoFilter filter = new EchoFilter();
+
+    @Test
+    void shouldRetryWithEcho() throws ExecutionException, InterruptedException {
+        CompletableFuture<CoapResponse> resp = filter.apply(post("/door/unlock"), this::handle1);
+
+        assertEquals(ok("OK"), resp.get());
+    }
+
+    @Test
+    void shouldForwardErrorMessage() throws ExecutionException, InterruptedException {
+        CompletableFuture<CoapResponse> resp = filter.apply(post("/door/unlock"), __ -> coapResponse(C401_UNAUTHORIZED).toFuture());
+
+        assertEquals(C401_UNAUTHORIZED, resp.get().getCode());
+    }
+
+    @Test
+    @DisplayName("should not repeat on unauthorized response")
+    void test3() throws ExecutionException, InterruptedException {
+        CompletableFuture<CoapResponse> resp = filter.apply(post("/door/unlock"), __ ->
+                coapResponse(C401_UNAUTHORIZED).options(it -> it.echo(Opaque.of("1"))).toFuture()
+        );
+
+        assertEquals(C401_UNAUTHORIZED, resp.get().getCode());
+    }
+
+    private CompletableFuture<CoapResponse> handle1(CoapRequest request) {
+        if (Objects.equals(Opaque.of("echo1"), request.options().getEcho())) {
+            return ok("OK").toFuture();
+        } else {
+            return CoapResponse.of(C401_UNAUTHORIZED)
+                    .options(it -> it.echo(Opaque.of("echo1")))
+                    .toFuture();
+        }
+    }
+
+}

--- a/coap-core/src/test/java/com/mbed/coap/server/messaging/RequestTagSupplierTest.java
+++ b/coap-core/src/test/java/com/mbed/coap/server/messaging/RequestTagSupplierTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022-2023 java-coap contributors (https://github.com/open-coap/java-coap)
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mbed.coap.server.messaging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+
+public class RequestTagSupplierTest {
+
+    @Test
+    void shouldGeneratedSequentialRequestTags() {
+        RequestTagSupplier requestTagSupplier = RequestTagSupplier.createSequential(0);
+
+        assertEquals("01", requestTagSupplier.next().toHex());
+        assertEquals("02", requestTagSupplier.next().toHex());
+        assertEquals("03", requestTagSupplier.next().toHex());
+    }
+
+    @Test
+    void shouldGeneratedSequentialRequestTags_lardInit() {
+        RequestTagSupplier requestTagSupplier = RequestTagSupplier.createSequential(0x7ffffffd);
+
+        assertEquals("7ffffffe", requestTagSupplier.next().toHex());
+        assertEquals("7fffffff", requestTagSupplier.next().toHex());
+        assertEquals("00", requestTagSupplier.next().toHex());
+        assertEquals("01", requestTagSupplier.next().toHex());
+    }
+}

--- a/coap-core/src/testFixtures/java/protocolTests/utils/CoapPacketBuilder.java
+++ b/coap-core/src/testFixtures/java/protocolTests/utils/CoapPacketBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 java-coap contributors (https://github.com/open-coap/java-coap)
+ * Copyright (C) 2022-2023 java-coap contributors (https://github.com/open-coap/java-coap)
  * Copyright (C) 2011-2021 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -211,4 +211,8 @@ public class CoapPacketBuilder {
         return this;
     }
 
+    public CoapPacketBuilder reqTag(String hex) {
+        coapPacket.headers().setRequestTag(Opaque.decodeHex(hex));
+        return this;
+    }
 }


### PR DESCRIPTION
* Partial support for [RFC 9175](https://datatracker.ietf.org/doc/html/rfc9175)
  - Request-Tag support for blockwise transfers
  - Client side handling of echo challenge
