### PR TITLE
Fix how CoapResponse transport context is applied

### DIFF
--- a/coap-core/src/main/java/com/mbed/coap/packet/CoapPacket.java
+++ b/coap-core/src/main/java/com/mbed/coap/packet/CoapPacket.java
@@ -181,7 +181,7 @@ public class CoapPacket {
 
     public CoapPacket createResponseFrom(CoapResponse coapResponse) {
         CoapPacket response = new CoapPacket(this.getRemoteAddress());
-        response.setTransportContext(this.transportContext.with(coapResponse.getTransContext()));
+        response.setTransportContext(coapResponse.getTransContext());
         response.setCode(coapResponse.getCode());
         response.setToken(getToken());
         response.setPayload(coapResponse.getPayload());

--- a/coap-core/src/test/java/com/mbed/coap/server/messaging/CoapRequestConverterTest.java
+++ b/coap-core/src/test/java/com/mbed/coap/server/messaging/CoapRequestConverterTest.java
@@ -81,6 +81,6 @@ class CoapRequestConverterTest {
                 newCoapPacket(LOCAL_5683).mid(1300).token(13).post().uriPath("/test2").payload("test").context(TransportContext.of(DUMMY_KEY_IN, true)).build(), service
         );
 
-        assertEquals(newCoapPacket(LOCAL_5683).ack(Code.C205_CONTENT).mid(1300).token(13).payload("ok").context(TransportContext.of(DUMMY_KEY_IN, true).with(DUMMY_KEY_OUT, true)).build(), resp.join());
+        assertEquals(newCoapPacket(LOCAL_5683).ack(Code.C205_CONTENT).mid(1300).token(13).payload("ok").context(TransportContext.of(DUMMY_KEY_OUT, true)).build(), resp.join());
     }
 }

--- a/coap-mbedtls/build.gradle.kts
+++ b/coap-mbedtls/build.gradle.kts
@@ -6,8 +6,8 @@ description = "coap-mbedtls"
 
 dependencies {
     api(project(":coap-core"))
-    api("io.github.open-coap:kotlin-mbedtls:1.27.0")
-    api("io.github.open-coap:kotlin-mbedtls-netty:1.27.0")
+    api("io.github.open-coap:kotlin-mbedtls:1.28.0")
+    api("io.github.open-coap:kotlin-mbedtls-netty:1.28.0")
 
     testImplementation(project(":coap-netty"))
 

--- a/coap-mbedtls/src/main/java/org/opencoap/transport/mbedtls/DtlsSessionSuspensionFilter.java
+++ b/coap-mbedtls/src/main/java/org/opencoap/transport/mbedtls/DtlsSessionSuspensionFilter.java
@@ -17,7 +17,7 @@ package org.opencoap.transport.mbedtls;
 
 import static com.mbed.coap.transport.TransportContext.NON_CONFIRMABLE;
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.opencoap.transport.mbedtls.DtlsTransportContext.DTLS_SESSION_EXPIRATION_HINT;
+import static org.opencoap.transport.mbedtls.DtlsTransportContext.DTLS_SESSION_SUSPENSION_HINT;
 import com.mbed.coap.packet.CoapRequest;
 import com.mbed.coap.packet.CoapResponse;
 import com.mbed.coap.transport.TransportContext;
@@ -25,7 +25,7 @@ import com.mbed.coap.utils.Filter;
 import com.mbed.coap.utils.Service;
 import java.util.concurrent.CompletableFuture;
 
-public class DtlsSessionExpirationFilter implements Filter.SimpleFilter<CoapRequest, CoapResponse> {
+public class DtlsSessionSuspensionFilter implements Filter.SimpleFilter<CoapRequest, CoapResponse> {
 
     @Override
     public CompletableFuture<CoapResponse> apply(CoapRequest request, Service<CoapRequest, CoapResponse> service) {
@@ -35,6 +35,6 @@ public class DtlsSessionExpirationFilter implements Filter.SimpleFilter<CoapRequ
 
         return service
                 .apply(request)
-                .thenCompose(resp -> completedFuture(resp.withContext(TransportContext.of(DTLS_SESSION_EXPIRATION_HINT, true))));
+                .thenCompose(resp -> completedFuture(resp.withContext(TransportContext.of(DTLS_SESSION_SUSPENSION_HINT, true))));
     }
 }

--- a/coap-mbedtls/src/main/java/org/opencoap/transport/mbedtls/DtlsTransportContext.java
+++ b/coap-mbedtls/src/main/java/org/opencoap/transport/mbedtls/DtlsTransportContext.java
@@ -34,7 +34,7 @@ public class DtlsTransportContext {
     public static final TransportContext.Key<String> DTLS_PEER_CERTIFICATE_SUBJECT = new TransportContext.Key<>(null);
     public static final TransportContext.Key<byte[]> DTLS_CID = new TransportContext.Key<>(null);
     public static final TransportContext.Key<Instant> DTLS_SESSION_START_TIMESTAMP = new TransportContext.Key<>(null);
-    public static final TransportContext.Key<Boolean> DTLS_SESSION_EXPIRATION_HINT = new TransportContext.Key<>(false);
+    public static final TransportContext.Key<Boolean> DTLS_SESSION_SUSPENSION_HINT = new TransportContext.Key<>(false);
 
     public static final BiFunction<CoapPacket, ChannelHandlerContext, DatagramPacket> DTLS_COAP_TO_DATAGRAM_CONVERTER = (coapPacket, ctx) -> {
         ByteBuf buf = ctx.alloc().buffer(coapPacket.getPayload().size() + 128);
@@ -49,7 +49,7 @@ public class DtlsTransportContext {
 
         TransportContext dtlsContext = TransportContext
                 .of(DTLS_AUTHENTICATION, dtlsSessionContext.getAuthenticationContext())
-                .with(DTLS_SESSION_EXPIRATION_HINT, dtlsSessionContext.getSessionExpirationHint());
+                .with(DTLS_SESSION_SUSPENSION_HINT, dtlsSessionContext.getSessionSuspensionHint());
         if (dtlsSessionContext.getPeerCertificateSubject() != null) {
             dtlsContext = dtlsContext.with(DTLS_PEER_CERTIFICATE_SUBJECT, dtlsSessionContext.getPeerCertificateSubject());
         }
@@ -69,7 +69,7 @@ public class DtlsTransportContext {
                 transportContext.get(DTLS_PEER_CERTIFICATE_SUBJECT),
                 transportContext.get(DTLS_CID),
                 transportContext.get(DTLS_SESSION_START_TIMESTAMP),
-                transportContext.get(DTLS_SESSION_EXPIRATION_HINT)
+                transportContext.get(DTLS_SESSION_SUSPENSION_HINT)
         );
     }
 }

--- a/coap-mbedtls/src/main/java/org/opencoap/transport/mbedtls/MbedtlsCoapTransport.java
+++ b/coap-mbedtls/src/main/java/org/opencoap/transport/mbedtls/MbedtlsCoapTransport.java
@@ -74,7 +74,7 @@ public class MbedtlsCoapTransport implements CoapTransport {
     @Override
     public CompletableFuture<Boolean> sendPacket(CoapPacket coapPacket) {
         ByteBuffer buf = ByteBuffer.wrap(CoapSerializer.serialize(coapPacket));
-        return dtlsTransport.send(new Packet<>(buf, coapPacket.getRemoteAddress()));
+        return dtlsTransport.send(new Packet<>(buf, coapPacket.getRemoteAddress(), DtlsTransportContext.toDtlsSessionContext(coapPacket.getTransportContext())));
     }
 
     @Override

--- a/coap-mbedtls/src/test/java/org/opencoap/transport/mbedtls/DtlsSessionExpirationFilterTest.java
+++ b/coap-mbedtls/src/test/java/org/opencoap/transport/mbedtls/DtlsSessionExpirationFilterTest.java
@@ -26,7 +26,7 @@ import com.mbed.coap.utils.Service;
 import org.junit.jupiter.api.Test;
 
 class DtlsSessionExpirationFilterTest {
-    private final Service<CoapRequest, CoapResponse> service = (new DtlsSessionExpirationFilter()).then(coapRequest -> completedFuture(of(Code.C201_CREATED)));
+    private final Service<CoapRequest, CoapResponse> service = (new DtlsSessionSuspensionFilter()).then(coapRequest -> completedFuture(of(Code.C201_CREATED)));
 
     @Test
     void shouldReturnBadRequestWhenRequestIsConfirmable() {
@@ -37,6 +37,6 @@ class DtlsSessionExpirationFilterTest {
     void shouldReturnResponseWithExpirationHint() {
         CoapResponse resp = service.apply(CoapRequest.get("/test").context(TransportContext.of(TransportContext.NON_CONFIRMABLE, true)).build()).join();
         assertEquals(Code.C201_CREATED, resp.getCode());
-        assertTrue(resp.getTransContext().get(DtlsTransportContext.DTLS_SESSION_EXPIRATION_HINT));
+        assertTrue(resp.getTransContext().get(DtlsTransportContext.DTLS_SESSION_SUSPENSION_HINT));
     }
 }

--- a/coap-mbedtls/src/test/java/org/opencoap/transport/mbedtls/DtlsTransportContextTest.java
+++ b/coap-mbedtls/src/test/java/org/opencoap/transport/mbedtls/DtlsTransportContextTest.java
@@ -23,8 +23,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opencoap.transport.mbedtls.DtlsTransportContext.DTLS_AUTHENTICATION;
 import static org.opencoap.transport.mbedtls.DtlsTransportContext.DTLS_CID;
 import static org.opencoap.transport.mbedtls.DtlsTransportContext.DTLS_PEER_CERTIFICATE_SUBJECT;
-import static org.opencoap.transport.mbedtls.DtlsTransportContext.DTLS_SESSION_EXPIRATION_HINT;
 import static org.opencoap.transport.mbedtls.DtlsTransportContext.DTLS_SESSION_START_TIMESTAMP;
+import static org.opencoap.transport.mbedtls.DtlsTransportContext.DTLS_SESSION_SUSPENSION_HINT;
 import com.mbed.coap.transport.TransportContext;
 import java.time.Instant;
 import java.util.Collections;
@@ -41,7 +41,7 @@ public class DtlsTransportContextTest {
         assertNull(transCtx.get(DTLS_PEER_CERTIFICATE_SUBJECT));
         assertNull(transCtx.get(DTLS_CID));
         assertNull(transCtx.get(DTLS_SESSION_START_TIMESTAMP));
-        assertFalse(transCtx.get(DTLS_SESSION_EXPIRATION_HINT));
+        assertFalse(transCtx.get(DTLS_SESSION_SUSPENSION_HINT));
 
         assertEquals(transCtx, TransportContext.EMPTY);
     }
@@ -57,6 +57,6 @@ public class DtlsTransportContextTest {
         assertEquals("CN:aa", transCtx.get(DTLS_PEER_CERTIFICATE_SUBJECT));
         assertEquals(Instant.ofEpochSecond(123456789), transCtx.get(DTLS_SESSION_START_TIMESTAMP));
         assertArrayEquals(new byte[]{1, 2}, transCtx.get(DTLS_CID));
-        assertTrue(transCtx.get(DTLS_SESSION_EXPIRATION_HINT));
+        assertTrue(transCtx.get(DTLS_SESSION_SUSPENSION_HINT));
     }
 }

--- a/coap-mbedtls/src/test/java/org/opencoap/transport/mbedtls/MbedtlsCoapTransportTest.java
+++ b/coap-mbedtls/src/test/java/org/opencoap/transport/mbedtls/MbedtlsCoapTransportTest.java
@@ -38,6 +38,7 @@ import com.mbed.coap.transport.TransportContext;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
+import java.util.HashMap;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -70,8 +71,10 @@ class MbedtlsCoapTransportTest {
                         })
                         .post("/auth", it -> {
                             String name = it.options().getUriQueryMap().get("name");
-                            dtlsServer.putSessionAuthenticationContext(it.getPeerAddress(), "auth", name);
-                            return completedFuture(CoapResponse.of(Code.C201_CREATED));
+
+                            HashMap<String, String> authCtx = new HashMap<>();
+                            authCtx.put("auth", name);
+                            return CoapResponse.coapResponse(Code.C201_CREATED).addContext(DTLS_AUTHENTICATION, authCtx).toFuture();
                         })
                         .get("/auth", it -> {
                             String name = it.getTransContext(DTLS_AUTHENTICATION).get("auth");


### PR DESCRIPTION
1. Don't merge inbound and outbound contexts on the way of CoapResponse back.
2. Fixing a bug when transport context was not passed to DtlsTransport from CoapResponse for non-Netty implementation.