### PR TITLE
feat(coap-core): Add java-coap specific header option for correlation tags

### DIFF
--- a/coap-core/src/main/java/com/mbed/coap/packet/BasicHeaderOptions.java
+++ b/coap-core/src/main/java/com/mbed/coap/packet/BasicHeaderOptions.java
@@ -177,7 +177,14 @@ public class BasicHeaderOptions {
         if (unrecognizedOptions == null) {
             unrecognizedOptions = new HashMap<>();
         }
-        unrecognizedOptions.put(optionNumber, new RawOption(optionNumber, data));
+        if (data != null) {
+            unrecognizedOptions.put(optionNumber, new RawOption(optionNumber, data));
+        } else {
+            unrecognizedOptions.remove(optionNumber);
+        }
+        if (unrecognizedOptions.isEmpty()) {
+            unrecognizedOptions = null;
+        }
         return true;
     }
 

--- a/coap-core/src/main/java/com/mbed/coap/packet/CoapOptionsBuilder.java
+++ b/coap-core/src/main/java/com/mbed/coap/packet/CoapOptionsBuilder.java
@@ -97,6 +97,17 @@ public class CoapOptionsBuilder {
         return this;
     }
 
+    public CoapOptionsBuilder unsetCorrelationTag() {
+        options.setCorrelationTag(null);
+        return this;
+    }
+
+    public CoapOptionsBuilder unsetCustom(int optionNumber) {
+        options.put(optionNumber, null);
+        return this;
+    }
+
+
     public CoapOptionsBuilder block1Req(BlockOption block) {
         options.setBlock1Req(block);
         return this;
@@ -203,4 +214,10 @@ public class CoapOptionsBuilder {
         options.setRequestTag(requestTag);
         return this;
     }
+
+    public CoapOptionsBuilder correlationTag(String correlationTag) {
+        options.setCorrelationTag(correlationTag);
+        return this;
+    }
+
 }

--- a/coap-core/src/test/java/com/mbed/coap/packet/CoapOptionsBuilderTest.java
+++ b/coap-core/src/test/java/com/mbed/coap/packet/CoapOptionsBuilderTest.java
@@ -71,6 +71,7 @@ public class CoapOptionsBuilderTest {
                 .echo(decodeHex("248618b4"))
                 .requestTag(decodeHex("da611128"))
                 .custom(1000, decodeHex("010203"))
+                .correlationTag("RequestId123")
                 .build();
 
         HeaderOptions expected = new HeaderOptions();
@@ -95,6 +96,7 @@ public class CoapOptionsBuilderTest {
         expected.setEcho(decodeHex("248618b4"));
         expected.setRequestTag(decodeHex("da611128"));
         expected.put(1000, decodeHex("010203"));
+        expected.setCorrelationTag("RequestId123");
 
         assertEquals(expected, options);
     }
@@ -106,6 +108,7 @@ public class CoapOptionsBuilderTest {
                 .block2Res(2, BlockSize.S_256, false)
                 .block1Req(0, BlockSize.S_256, true)
                 .size2Res(535)
+                .custom(65000, Opaque.of("custom"))
                 .build();
 
         HeaderOptions unsetOptions = CoapOptionsBuilder.from(options)
@@ -113,6 +116,7 @@ public class CoapOptionsBuilderTest {
                 .unsetBlock1Req()
                 .unsetBlock2Res()
                 .unsetSize2Res()
+                .unsetCustom(65000)
                 .build();
 
         assertEquals(new HeaderOptions(), unsetOptions);

--- a/coap-core/src/test/java/com/mbed/coap/packet/HeaderOptionsTest.java
+++ b/coap-core/src/test/java/com/mbed/coap/packet/HeaderOptionsTest.java
@@ -173,6 +173,7 @@ public class HeaderOptionsTest {
         hdr.setObserve(4321);
         hdr.setEcho(decodeHex("0102030405060708090a"));
         hdr.setRequestTag(Opaque.of("tag-0001"));
+        hdr.setCorrelationTag("RequestId1234");
 
         HeaderOptions hdr2 = deserialize(serialize(hdr));
 
@@ -344,6 +345,15 @@ public class HeaderOptionsTest {
 
         hdr3.setObserve(1234);
         hdr4.setObserve(1234);
+        assertTrue(hdr3.equals(hdr4));
+
+        hdr3.setCorrelationTag("1234");
+        hdr4.setCorrelationTag("12345");
+        assertNotEquals(hdr3.hashCode(), hdr4.hashCode());
+        assertFalse(hdr3.equals(hdr4));
+
+        hdr3.setCorrelationTag("1234");
+        hdr4.setCorrelationTag("1234");
         assertTrue(hdr3.equals(hdr4));
     }
 


### PR DESCRIPTION
The option allows to send and receive correlation tags to match CoAP requests and responses with any application specific actions.

Option number is a randomly generated number (29643) from the Expert Review range.