### PR TITLE
build: upgrade kotlin-mbedtls to version 1.32.1

### DIFF
--- a/coap-mbedtls/build.gradle.kts
+++ b/coap-mbedtls/build.gradle.kts
@@ -6,8 +6,8 @@ description = "coap-mbedtls"
 
 dependencies {
     api(project(":coap-core"))
-    api("io.github.open-coap:kotlin-mbedtls:1.31.1")
-    api("io.github.open-coap:kotlin-mbedtls-netty:1.31.1")
+    api("io.github.open-coap:kotlin-mbedtls:1.32.1")
+    api("io.github.open-coap:kotlin-mbedtls-netty:1.32.1")
 
     testImplementation(project(":coap-netty"))
 


### PR DESCRIPTION
kotlin-mbedtls version 1.32.1 contains the mbedtls 4.0.0