### PR TITLE
Drop Java 8 support: require Java 17 (resolves #90)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,7 @@ subprojects {
         withType<JavaCompile> {
             options.encoding = "UTF-8"
             if (this.name == "compileJava") {
-                options.release.set(8)
+                options.release.set(17)
                 // options.setDeprecation(true)
                 options.compilerArgs.add("-Xlint:-options")
                 options.compilerArgs.add("-Werror")


### PR DESCRIPTION
Resolves #90.

Sets the minimum supported Java version to **17** by raising the compile target:

- `build.gradle.kts`: `options.release.set(8)` → `options.release.set(17)` — applied to all 7 modules via the shared `compileJava` configuration.

CI already runs the matrix `['17','21','25']` (no Java 8/11 axis), so no workflow change is needed.

## Verification
Ran the repo's own CI command on Temurin 17 — `./gradlew build jacocoTestReport javadoc`: **BUILD SUCCESSFUL**, all tests green (~726 executed across the 7 modules, 1 skipped), identical to the release-8 baseline. `-Werror` stayed clean.

🤖 Migrated with the [bump-java-version](https://github.com/vasiliy-mikhailov/bump-java-version-skill) skill.
