### PR TITLE
fix(coap-core): use correct encoding on uri-query

### DIFF
--- a/coap-core/src/main/java/com/mbed/coap/packet/BasicHeaderOptions.java
+++ b/coap-core/src/main/java/com/mbed/coap/packet/BasicHeaderOptions.java
@@ -22,14 +22,17 @@ import com.mbed.coap.exception.CoapMessageFormatException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * Implements CoAP basic header options.
@@ -63,7 +66,12 @@ public class BasicHeaderOptions {
     private String locationPath;
     private String locationQuery;
     private String uriPath;
-    private String uriQuery;
+    /**
+     * Each element is the verbatim value of a single Uri-Query option, holding already decoded
+     * characters as described in RFC 7252, section 6.4. Values are never percent-encoded and may
+     * contain any character, including '&amp;', '=' and '?'. Null when no Uri-Query option is present.
+     */
+    private List<String> uriQuery;
     private Integer accept;
     private Opaque[] ifMatch;
     private Boolean ifNonMatch;
@@ -97,7 +105,7 @@ public class BasicHeaderOptions {
                 uriPath = DataConvertingUtility.extendOption(uriPath, data, "/", true);
                 break;
             case URI_QUERY:
-                uriQuery = DataConvertingUtility.extendOption(uriQuery, data, "&", false);
+                addUriQuery(data.toUtf8String());
                 break;
             case PROXY_URI:
                 proxyUri = data.toUtf8String();
@@ -223,7 +231,13 @@ public class BasicHeaderOptions {
             list.add(RawOption.fromString(URI_PATH, DataConvertingUtility.split(uriPath, '/')));
         }
         if (uriQuery != null) {
-            list.add(RawOption.fromString(URI_QUERY, uriQuery.split("&")));
+            // not RawOption.fromString(int, String[]), which drops a leading empty element for
+            // the benefit of Uri-Path. A zero length Uri-Query option is a legal, distinct option.
+            Opaque[] queryValues = new Opaque[uriQuery.size()];
+            for (int i = 0; i < queryValues.length; i++) {
+                queryValues[i] = Opaque.of(uriQuery.get(i));
+            }
+            list.add(new RawOption(URI_QUERY, queryValues));
         }
         if (proxyUri != null) {
             list.add(RawOption.fromString(PROXY_URI, proxyUri));
@@ -267,7 +281,7 @@ public class BasicHeaderOptions {
             sb.append(" URI:").append(uriPath);
         }
         if (uriQuery != null) {
-            sb.append('?').append(uriQuery);
+            sb.append('?').append(String.join("&", uriQuery));
         }
         if (locationPath != null) {
             sb.append(" Loc:").append(locationPath);
@@ -470,21 +484,119 @@ public class BasicHeaderOptions {
     }
 
     /**
-     * @return the uriQuery
+     * Returns all Uri-Query option values joined with '&amp;'.
+     *
+     * @return joined Uri-Query values, or null when no Uri-Query option is present
+     * @deprecated the returned string looks like a URL query component but is not one. Uri-Query
+     * option values hold already decoded characters (RFC 7252, section 6.4), so they are
+     * never percent-encoded, and a value containing '&amp;' is indistinguishable from an
+     * option boundary. Do not splice the result into a URL. Use
+     * {@link #getUriQueryEncoded()} to compose a CoAP URI, {@link #getUriQueryList()} for
+     * the unambiguous per-option values, or {@link #getUriQueryMap()} for name/value pairs.
      */
+    @Deprecated
     public String getUriQuery() {
-        return uriQuery;
+        return uriQuery == null ? null : String.join("&", uriQuery);
     }
 
     /**
-     * @param uriQuery the uriQuery to set
+     * Returns the query component of the CoAP URI built from the Uri-Query options, following the
+     * rules of RFC 7252, section 6.5, step 8. Each option value is percent-encoded and the results
+     * are joined with '&amp;'. The leading '?' is not included.
+     *
+     * <p>Encoding leaves any character in the "unreserved" set, in the "sub-delims" set except
+     * '&amp;', or one of ':', '&#64;', '/' and '?' as is. Notably '+', '=', ';' and ',' are
+     * therefore <b>not</b> escaped, which is what makes the result a valid CoAP URI query. This is
+     * not <code>application/x-www-form-urlencoded</code>: if the result is destined for a consumer
+     * that decodes with those rules, for example an HTTP proxy target, a literal '+' will be read
+     * as a space. Use {@link #getUriQueryMap()} or {@link #getUriQueryList()} and apply that
+     * encoding instead.
+     *
+     * @return percent-encoded query, or null when no Uri-Query option is present
      */
+    public String getUriQueryEncoded() {
+        if (uriQuery == null) {
+            return null;
+        }
+        return uriQuery.stream()
+                .map(DataConvertingUtility::percentEncodeUriQueryOption)
+                .collect(Collectors.joining("&"));
+    }
+
+    /**
+     * Replaces all Uri-Query options, splitting the given string on '&amp;'.
+     *
+     * @param uriQuery '&amp;' separated query, empty string clears the option
+     * @deprecated splitting on '&amp;' cannot express a value that itself contains '&amp;'. Use
+     * {@link #setUriQueryList(List)} or {@link #addUriQuery(String)} instead.
+     */
+    @Deprecated
     public void setUriQuery(String uriQuery) {
         if (uriQuery.isEmpty()) {
             this.uriQuery = null;
         } else {
-            this.uriQuery = uriQuery;
+            this.uriQuery = new ArrayList<>(Arrays.asList(uriQuery.split("&")));
         }
+    }
+
+    /**
+     * Returns the value of each Uri-Query option, in order, exactly as carried on the wire.
+     * Values hold already decoded characters (RFC 7252, section 6.4), so they are never
+     * percent-encoded and may contain any character, including '&amp;', '=' and '?'.
+     *
+     * <p>This is the lossless view of the option: unlike {@link #getUriQuery()} it keeps option
+     * boundaries, and unlike {@link #getUriQueryMap()} it keeps repeated names and ordering.
+     *
+     * @return unmodifiable list of Uri-Query values, empty when no Uri-Query option is present
+     */
+    public List<String> getUriQueryList() {
+        if (uriQuery == null) {
+            return Collections.emptyList();
+        }
+        return Collections.unmodifiableList(uriQuery);
+    }
+
+    /**
+     * Replaces all Uri-Query options with the given values. Each value becomes one Uri-Query
+     * option and is written verbatim, so it must hold decoded characters, not percent-encoded ones.
+     *
+     * @param uriQuery Uri-Query values, null or empty clears the option
+     */
+    public void setUriQueryList(List<String> uriQuery) {
+        if (uriQuery == null || uriQuery.isEmpty()) {
+            this.uriQuery = null;
+        } else {
+            uriQuery.forEach(Objects::requireNonNull);
+            this.uriQuery = new ArrayList<>(uriQuery);
+        }
+    }
+
+    /**
+     * Replaces all Uri-Query options with the given values. Each value becomes one Uri-Query
+     * option and is written verbatim, so it must hold decoded characters, not percent-encoded ones.
+     *
+     * @param uriQuery Uri-Query values, null or empty clears the option
+     */
+    public void setUriQueryList(String... uriQuery) {
+        if (uriQuery == null) {
+            setUriQueryList((List<String>) null);
+        } else {
+            setUriQueryList(Arrays.asList(uriQuery));
+        }
+    }
+
+    /**
+     * Appends a single Uri-Query option. The value is written verbatim, so it must hold decoded
+     * characters, not percent-encoded ones.
+     *
+     * @param uriQuery Uri-Query value, typically in "name=value" form
+     */
+    public void addUriQuery(String uriQuery) {
+        Objects.requireNonNull(uriQuery);
+        if (this.uriQuery == null) {
+            this.uriQuery = new ArrayList<>(1);
+        }
+        this.uriQuery.add(uriQuery);
     }
 
     public void setAccept(short accept) {
@@ -550,11 +662,30 @@ public class BasicHeaderOptions {
         this.uriPort = uriPort;
     }
 
+    /**
+     * Returns Uri-Query options as decoded name to value pairs, in order. A value-less option
+     * maps to an empty string.
+     *
+     * <p>Names and values are not percent-encoded (RFC 7252, section 6.4), so they must be encoded
+     * before being placed into a URL. Repeated names collapse to the last occurrence, use
+     * {@link #getUriQueryList()} when repeats matter.
+     *
+     * @return name to value pairs, empty when no Uri-Query option is present
+     */
     public Map<String, String> getUriQueryMap() {
         if (uriQuery == null) {
             return Collections.emptyMap();
         }
-        return DataConvertingUtility.parseUriQuery(uriQuery);
+        Map<String, String> result = new LinkedHashMap<>();
+        for (String query : uriQuery) {
+            int eq = query.indexOf('=');
+            if (eq < 0) {
+                result.put(query, "");
+            } else {
+                result.put(query.substring(0, eq), query.substring(eq + 1));
+            }
+        }
+        return result;
     }
 
     public Integer getSize1() {
@@ -688,7 +819,7 @@ public class BasicHeaderOptions {
         opts.locationPath = locationPath;
         opts.locationQuery = locationQuery;
         opts.uriPath = uriPath;
-        opts.uriQuery = uriQuery;
+        opts.uriQuery = uriQuery == null ? null : new ArrayList<>(uriQuery);
         opts.accept = accept;
         opts.ifMatch = ifMatch;
         opts.ifNonMatch = ifNonMatch;

--- a/coap-core/src/main/java/com/mbed/coap/packet/CoapOptionsBuilder.java
+++ b/coap-core/src/main/java/com/mbed/coap/packet/CoapOptionsBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 java-coap contributors (https://github.com/open-coap/java-coap)
+ * Copyright (C) 2022-2026 java-coap contributors (https://github.com/open-coap/java-coap)
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/coap-core/src/main/java/com/mbed/coap/packet/CoapOptionsBuilder.java
+++ b/coap-core/src/main/java/com/mbed/coap/packet/CoapOptionsBuilder.java
@@ -16,6 +16,7 @@
 package com.mbed.coap.packet;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -166,23 +167,48 @@ public class CoapOptionsBuilder {
         return this;
     }
 
+    /**
+     * Replaces all Uri-Query options, splitting the given string on '&amp;'.
+     *
+     * @deprecated splitting on '&amp;' cannot express a value that itself contains '&amp;'. Use
+     *         {@link #query(String, String)} or {@link #queries(List)} instead.
+     */
+    @Deprecated
     public CoapOptionsBuilder query(String query) {
         options.setUriQuery(query);
         return this;
     }
 
+    /**
+     * Replaces all Uri-Query options, one per given value. Values are written verbatim, so they
+     * must hold decoded characters (RFC 7252, section 6.4), not percent-encoded ones.
+     */
+    public CoapOptionsBuilder queries(List<String> queries) {
+        options.setUriQueryList(queries);
+        return this;
+    }
+
+    /**
+     * Replaces all Uri-Query options, one per given value. Values are written verbatim, so they
+     * must hold decoded characters (RFC 7252, section 6.4), not percent-encoded ones. Calling it
+     * with no arguments removes the Uri-Query options.
+     */
+    public CoapOptionsBuilder queries(String... queries) {
+        options.setUriQueryList(queries);
+        return this;
+    }
+
+    /**
+     * Appends a single Uri-Query option. Both name and value are written verbatim, so they must
+     * hold decoded characters (RFC 7252, section 6.4), not percent-encoded ones. The value may
+     * contain any character, including '&amp;', '=' and '?', because it is carried in its own option.
+     */
     public CoapOptionsBuilder query(String name, String val) {
-        if (name.isEmpty() || name.contains("=") || name.contains("&") || name.contains("?")
-                || val.isEmpty() || val.contains("=") || val.contains("&") || val.contains("?")) {
+        if (name.isEmpty() || name.contains("=") || name.contains("&")) {
             throw new IllegalArgumentException("Non valid characters provided in query");
         }
-        final StringBuilder query = new StringBuilder();
-        if (options.getUriQuery() != null) {
-            query.append(options.getUriQuery());
-            query.append('&');
-        }
-        query.append(name).append('=').append(val);
-        return query(query.toString());
+        options.addUriQuery(name + '=' + val);
+        return this;
     }
 
     public CoapOptionsBuilder ifMatch(Opaque etag) {

--- a/coap-core/src/main/java/com/mbed/coap/packet/DataConvertingUtility.java
+++ b/coap-core/src/main/java/com/mbed/coap/packet/DataConvertingUtility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 java-coap contributors (https://github.com/open-coap/java-coap)
+ * Copyright (C) 2022-2026 java-coap contributors (https://github.com/open-coap/java-coap)
  * Copyright (C) 2011-2021 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/coap-core/src/main/java/com/mbed/coap/packet/DataConvertingUtility.java
+++ b/coap-core/src/main/java/com/mbed/coap/packet/DataConvertingUtility.java
@@ -16,6 +16,7 @@
  */
 package com.mbed.coap.packet;
 
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -27,6 +28,10 @@ import java.util.Map;
  * Utility class that provides static helper methods for creating and parsing CoAP packet
  */
 public final class DataConvertingUtility {
+
+    private static final char[] HEX_DIGITS = "0123456789ABCDEF".toCharArray();
+    /** RFC 3986 "sub-delims", without '&amp;' which separates Uri-Query options. */
+    private static final String QUERY_SUB_DELIMS = "!$'()*+,;=";
 
     private DataConvertingUtility() {
         //keep private
@@ -73,6 +78,55 @@ public final class DataConvertingUtility {
             }
         }
         return result;
+    }
+
+    /**
+     * Percent-encodes the value of a <b>single</b> Uri-Query option for use in a CoAP URI,
+     * following the rules of RFC 7252, section 6.5, step 8. Any character outside the "unreserved"
+     * set, the "sub-delims" set except '&amp;', and ':', '&#64;', '/' and '?' is replaced by the
+     * uppercase percent-encoded form of its UTF-8 bytes.
+     *
+     * <p>This takes one option, not a whole query string. '&amp;' is a separator that only exists
+     * once options are joined into a URI, so it is escaped here: passing <code>"a=1&amp;b=2"</code>
+     * yields <code>"a=1%26b=2"</code>, a single option, not two. To encode a complete query use
+     * {@link BasicHeaderOptions#getUriQueryEncoded()}.
+     *
+     * <p>Notably '+', '=', ';' and ',' are <b>not</b> escaped, which is what makes the result a
+     * valid CoAP URI query. This is not <code>application/x-www-form-urlencoded</code>: a consumer
+     * decoding with those rules, for example an HTTP proxy target, reads a literal '+' as a space.
+     *
+     * @param value Uri-Query option value, holding already decoded characters
+     * @return percent-encoded value
+     */
+    public static String percentEncodeUriQueryOption(String value) {
+        // Encoded by hand because no JDK helper matches these rules. URLEncoder implements
+        // application/x-www-form-urlencoded, which escapes '=', emits '+' for space and escapes
+        // '+' ',' ';' '/' '?' that must stay literal here. java.net.URI keeps '&' unescaped, since
+        // it is legal in a query component, which would make two options indistinguishable from
+        // one option whose value contains '&'.
+        StringBuilder sb = new StringBuilder(value.length());
+        for (byte rawByte : value.getBytes(StandardCharsets.UTF_8)) {
+            int chr = rawByte & 0xFF;
+            if (isAllowedInUriQuery(chr)) {
+                sb.append((char) chr);
+            } else {
+                sb.append('%').append(HEX_DIGITS[chr >> 4]).append(HEX_DIGITS[chr & 0x0F]);
+            }
+        }
+        return sb.toString();
+    }
+
+    private static boolean isAllowedInUriQuery(int chr) {
+        return isUnreserved(chr)
+                || QUERY_SUB_DELIMS.indexOf(chr) >= 0
+                || chr == ':' || chr == '@' || chr == '/' || chr == '?';
+    }
+
+    private static boolean isUnreserved(int chr) {
+        return chr >= 'a' && chr <= 'z'
+                || chr >= 'A' && chr <= 'Z'
+                || chr >= '0' && chr <= '9'
+                || chr == '-' || chr == '.' || chr == '_' || chr == '~';
     }
 
     public static Map<String, List<String>> parseUriQueryMult(String uriQuery) throws ParseException {

--- a/coap-core/src/test/java/com/mbed/coap/packet/CoapOptionsBuilderTest.java
+++ b/coap-core/src/test/java/com/mbed/coap/packet/CoapOptionsBuilderTest.java
@@ -18,7 +18,11 @@ package com.mbed.coap.packet;
 import static com.mbed.coap.packet.CoapOptionsBuilder.options;
 import static com.mbed.coap.packet.Opaque.decodeHex;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 
@@ -29,9 +33,44 @@ public class CoapOptionsBuilderTest {
         failQueryWithNonValidChars("", "2");
         failQueryWithNonValidChars("&", "2");
         failQueryWithNonValidChars("=", "54");
-        failQueryWithNonValidChars("f", "");
-        failQueryWithNonValidChars("f", "&");
-        failQueryWithNonValidChars("f", "=");
+    }
+
+    @Test
+    public void shouldAllowAnyCharacterInQueryValue() {
+        // each value is carried in its own Uri-Query option, so no character is a separator
+        assertEquals(singletonList("f="), options().query("f", "").build().getUriQueryList());
+        assertEquals(singletonList("f=&"), options().query("f", "&").build().getUriQueryList());
+        assertEquals(singletonList("f=="), options().query("f", "=").build().getUriQueryList());
+        assertEquals(singletonList("f=?"), options().query("f", "?").build().getUriQueryList());
+        assertEquals(singletonList("f=1.0.0+sha"), options().query("f", "1.0.0+sha").build().getUriQueryList());
+    }
+
+    @Test
+    public void shouldKeepRepeatedQueryNames() {
+        HeaderOptions options = options().query("a", "1").query("a", "2").build();
+
+        assertEquals(asList("a=1", "a=2"), options.getUriQueryList());
+    }
+
+    @Test
+    public void shouldSetQueriesFromVarargs() {
+        assertEquals(asList("a=1", "b=2"), options().queries("a=1", "b=2").build().getUriQueryList());
+
+        // same result as the List overload
+        assertEquals(options().queries(asList("a=1", "b=2")).build().getUriQueryList(),
+                options().queries("a=1", "b=2").build().getUriQueryList());
+
+        // values are verbatim, so a separator inside a value stays inside that one option
+        assertEquals(singletonList("filter=a&b"), options().queries("filter=a&b").build().getUriQueryList());
+    }
+
+    @Test
+    public void shouldClearQueriesWithNoVarargs() {
+        HeaderOptions options = options().query("a", "1").queries().build();
+
+        assertEquals(emptyList(), options.getUriQueryList());
+        // absent, not present-and-empty
+        assertNull(options.getUriQueryEncoded());
     }
 
     private static void failQueryWithNonValidChars(String name, String val) {

--- a/coap-core/src/test/java/com/mbed/coap/packet/CoapOptionsBuilderTest.java
+++ b/coap-core/src/test/java/com/mbed/coap/packet/CoapOptionsBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 java-coap contributors (https://github.com/open-coap/java-coap)
+ * Copyright (C) 2022-2026 java-coap contributors (https://github.com/open-coap/java-coap)
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,12 @@ package com.mbed.coap.packet;
 
 import static com.mbed.coap.packet.CoapOptionsBuilder.options;
 import static com.mbed.coap.packet.Opaque.decodeHex;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 

--- a/coap-core/src/test/java/com/mbed/coap/packet/DataConvertingUtilityTest.java
+++ b/coap-core/src/test/java/com/mbed/coap/packet/DataConvertingUtilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 java-coap contributors (https://github.com/open-coap/java-coap)
+ * Copyright (C) 2022-2026 java-coap contributors (https://github.com/open-coap/java-coap)
  * Copyright (C) 2011-2021 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/coap-core/src/test/java/com/mbed/coap/packet/DataConvertingUtilityTest.java
+++ b/coap-core/src/test/java/com/mbed/coap/packet/DataConvertingUtilityTest.java
@@ -18,15 +18,18 @@ package com.mbed.coap.packet;
 
 import static com.mbed.coap.packet.DataConvertingUtility.parseUriQuery;
 import static com.mbed.coap.packet.DataConvertingUtility.parseUriQueryMult;
+import static com.mbed.coap.packet.DataConvertingUtility.percentEncodeUriQueryOption;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.text.ParseException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class DataConvertingUtilityTest {
@@ -60,6 +63,67 @@ public class DataConvertingUtilityTest {
         assertEquals(q, parseUriQuery("par1="));
     }
 
+
+    @Nested
+    class PercentEncodeUriQueryOptionTest {
+
+        @Test
+        public void shouldPercentEncodeCharactersOutsideTheAllowedSet() {
+            assertEquals("filter=a%26b", percentEncodeUriQueryOption("filter=a&b"));
+            assertEquals("hello%20world", percentEncodeUriQueryOption("hello world"));
+            assertEquals("100%25", percentEncodeUriQueryOption("100%"));
+            assertEquals("a%22b%3Cc%3Ed%23e", percentEncodeUriQueryOption("a\"b<c>d#e"));
+        }
+
+        @Test
+        public void shouldEncodeExactlyTheCharactersOutsideTheRfc7252QuerySet() {
+            // spelled out from RFC 7252 6.5 step 8: unreserved / sub-delims except '&' / ':' '@' '/' '?'
+            String unreserved = "-._~";
+            String subDelimsWithoutSeparator = "!$'()*+,;=";
+            String alsoAllowed = ":@/?";
+
+            StringBuilder literal = new StringBuilder();
+            StringBuilder encoded = new StringBuilder();
+            for (char chr = 0x20; chr <= 0x7E; chr++) {
+                String single = String.valueOf(chr);
+                if (percentEncodeUriQueryOption(single).equals(single)) {
+                    literal.append(chr);
+                } else {
+                    encoded.append(chr);
+                    assertEquals(String.format("%%%02X", (int) chr), percentEncodeUriQueryOption(single));
+                }
+            }
+
+            for (char chr : (unreserved + subDelimsWithoutSeparator + alsoAllowed).toCharArray()) {
+                assertTrue(literal.indexOf(String.valueOf(chr)) >= 0, chr + " must stay literal");
+            }
+            assertEquals(" \"#%&<>[\\]^`{|}", encoded.toString());
+        }
+
+        @Test
+        public void shouldPercentEncodeUtf8BytesInUppercase() {
+            assertEquals("za%C5%BC%C3%B3%C5%82%C4%87", percentEncodeUriQueryOption("zażółć"));
+        }
+
+        @Test
+        public void shouldNotEncodePlusSign() {
+            // '+' is a sub-delim, so RFC 7252 leaves it literal. It does not survive a consumer that
+            // decodes as application/x-www-form-urlencoded, where a bare '+' means space -- such a
+            // consumer needs its own encoding, this method is not it.
+            assertEquals("current_version=1.2.3+build.7", percentEncodeUriQueryOption("current_version=1.2.3+build.7"));
+        }
+
+        @Test
+        public void shouldEncodeOneOptionSoSeparatorIsNotTreatedAsSuch() {
+            // encodes a single option, so '&' is data and gets escaped rather than passed through
+            assertEquals("a=1%26b=2", percentEncodeUriQueryOption("a=1&b=2"));
+        }
+
+        @Test
+        public void shouldEncodeEmptyValueToEmptyString() {
+            assertEquals("", percentEncodeUriQueryOption(""));
+        }
+    }
 
     @Test
     public void splitTest() throws Exception {

--- a/coap-core/src/test/java/com/mbed/coap/packet/HeaderOptionsTest.java
+++ b/coap-core/src/test/java/com/mbed/coap/packet/HeaderOptionsTest.java
@@ -470,8 +470,9 @@ public class HeaderOptionsTest {
 
         assertThatThrownBy(() -> h.setUriPath("no-leading-slash")).isExactlyInstanceOf(IllegalArgumentException.class);
 
-        h.setUriQuery("");
-        assertNull(h.getUriQuery());
+        h.setUriQueryList();
+        assertNull(h.getUriQueryEncoded());
+        assertTrue(h.getUriQueryList().isEmpty());
     }
 
     @Test
@@ -524,6 +525,124 @@ public class HeaderOptionsTest {
         assertEquals("", h2.getUriQueryMap().get("q"));
 
         assertEquals("?param1=val1&q&param2=val2 Loc:?q", h2.toString());
+    }
+
+    @Test
+    void shouldPercentEncodeUriQueryPerRfc7252() {
+        HeaderOptions h = new HeaderOptions();
+        h.setUriQueryList(Arrays.asList("filter=a&b", "note=hello world", "p=100%"));
+
+        // '&' inside a value is escaped, so the joined result is unambiguous
+        assertEquals("filter=a%26b&note=hello%20world&p=100%25", h.getUriQueryEncoded());
+    }
+
+    @Test
+    void shouldNotEncodeSubDelimsInUriQuery() {
+        HeaderOptions h = new HeaderOptions();
+        h.setUriQueryList(Arrays.asList("current_version=1.0.0+sha", "a=x,y;z", "b=!$'()*"));
+
+        // sub-delims other than '&', plus ':' '@' '/' '?', are legal unescaped in a CoAP URI query
+        assertEquals("current_version=1.0.0+sha&a=x,y;z&b=!$'()*", h.getUriQueryEncoded());
+    }
+
+    @Test
+    void shouldEncodeUriQueryAsUtf8() {
+        HeaderOptions h = new HeaderOptions();
+        h.addUriQuery("name=zażółć");
+
+        assertEquals("name=za%C5%BC%C3%B3%C5%82%C4%87", h.getUriQueryEncoded());
+    }
+
+    @Test
+    void shouldKeepSeparatorForEmptyUriQueryValue() {
+        HeaderOptions h = new HeaderOptions();
+        h.setUriQueryList(Arrays.asList("", "a=1"));
+
+        assertEquals("&a=1", h.getUriQueryEncoded());
+    }
+
+    @Test
+    void shouldRoundTripEmptyUriQueryValue() throws CoapException, IOException {
+        HeaderOptions h = new HeaderOptions();
+        h.setUriQueryList(Arrays.asList("", "a=1"));
+
+        HeaderOptions h2 = deserialize(serialize(h));
+
+        // a zero length Uri-Query option is its own option, not padding to be dropped
+        assertEquals(Arrays.asList("", "a=1"), h2.getUriQueryList());
+        assertEquals("&a=1", h2.getUriQueryEncoded());
+    }
+
+    @Test
+    void shouldReturnNullEncodedUriQueryWhenAbsent() {
+        assertNull(new HeaderOptions().getUriQueryEncoded());
+    }
+
+    @Test
+    void shouldRoundTripQueryValueContainingAmpersand() throws CoapException, IOException {
+        HeaderOptions h = new HeaderOptions();
+        h.setUriQueryList(Arrays.asList("filter=a&b", "page=1"));
+
+        HeaderOptions h2 = deserialize(serialize(h));
+
+        // option boundaries survive, so the '&' stays part of the value
+        assertEquals(Arrays.asList("filter=a&b", "page=1"), h2.getUriQueryList());
+        assertEquals("a&b", h2.getUriQueryMap().get("filter"));
+        assertEquals("1", h2.getUriQueryMap().get("page"));
+    }
+
+    @Test
+    void shouldNotTruncateQueryValueAtQuestionMark() throws CoapException, IOException {
+        HeaderOptions h = new HeaderOptions();
+        h.addUriQuery("redirect=/a?b=c");
+
+        HeaderOptions h2 = deserialize(serialize(h));
+
+        assertEquals("/a?b=c", h2.getUriQueryMap().get("redirect"));
+    }
+
+    @Test
+    void shouldKeepRepeatedQueryNames() throws CoapException, IOException {
+        HeaderOptions h = new HeaderOptions();
+        h.setUriQueryList(Arrays.asList("a=1", "a=2"));
+
+        HeaderOptions h2 = deserialize(serialize(h));
+
+        assertEquals(Arrays.asList("a=1", "a=2"), h2.getUriQueryList());
+        // the map view collapses repeats, keeping the last one
+        assertEquals("2", h2.getUriQueryMap().get("a"));
+    }
+
+    @Test
+    void shouldReturnEmptyQueryViewsWhenNoUriQuery() {
+        HeaderOptions h = new HeaderOptions();
+
+        assertEquals(Collections.emptyList(), h.getUriQueryList());
+        assertEquals(Collections.emptyMap(), h.getUriQueryMap());
+        assertNull(h.getUriQuery());
+    }
+
+    @Test
+    void shouldClearUriQueryWithEmptyList() {
+        HeaderOptions h = new HeaderOptions();
+        h.addUriQuery("a=1");
+
+        h.setUriQueryList(Collections.emptyList());
+
+        assertEquals(Collections.emptyList(), h.getUriQueryList());
+        assertNull(h.getUriQuery());
+    }
+
+    @Test
+    void shouldNotShareUriQueryListBetweenDuplicates() {
+        HeaderOptions h = new HeaderOptions();
+        h.addUriQuery("a=1");
+
+        HeaderOptions copy = h.duplicate();
+        copy.addUriQuery("b=2");
+
+        assertEquals(Collections.singletonList("a=1"), h.getUriQueryList());
+        assertEquals(Arrays.asList("a=1", "b=2"), copy.getUriQueryList());
     }
 
     @Test

--- a/coap-core/src/test/java/com/mbed/coap/packet/HeaderOptionsTest.java
+++ b/coap-core/src/test/java/com/mbed/coap/packet/HeaderOptionsTest.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.jupiter.api.Test;
@@ -628,6 +629,48 @@ public class HeaderOptionsTest {
         h.addUriQuery("a=1");
 
         h.setUriQueryList(Collections.emptyList());
+
+        assertEquals(Collections.emptyList(), h.getUriQueryList());
+        assertNull(h.getUriQuery());
+    }
+
+    @Test
+    void shouldClearUriQueryWithNullList() {
+        HeaderOptions h = new HeaderOptions();
+        h.addUriQuery("a=1");
+
+        h.setUriQueryList((List<String>) null);
+
+        assertEquals(Collections.emptyList(), h.getUriQueryList());
+        assertNull(h.getUriQuery());
+    }
+
+    @Test
+    void shouldClearUriQueryWithNullArray() {
+        HeaderOptions h = new HeaderOptions();
+        h.addUriQuery("a=1");
+
+        h.setUriQueryList((String[]) null);
+
+        assertEquals(Collections.emptyList(), h.getUriQueryList());
+        assertNull(h.getUriQuery());
+    }
+
+    @Test
+    void shouldSetUriQueryFromVarargs() {
+        HeaderOptions h = new HeaderOptions();
+
+        h.setUriQueryList("a=1", "filter=x&y");
+
+        assertEquals(Arrays.asList("a=1", "filter=x&y"), h.getUriQueryList());
+    }
+
+    @Test
+    void shouldClearUriQueryWithEmptyString() {
+        HeaderOptions h = new HeaderOptions();
+        h.addUriQuery("a=1");
+
+        h.setUriQuery("");
 
         assertEquals(Collections.emptyList(), h.getUriQueryList());
         assertNull(h.getUriQuery());

--- a/coap-core/src/testFixtures/java/com/mbed/coap/utils/CoapPacketAssertion.java
+++ b/coap-core/src/testFixtures/java/com/mbed/coap/utils/CoapPacketAssertion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 java-coap contributors (https://github.com/open-coap/java-coap)
+ * Copyright (C) 2022-2026 java-coap contributors (https://github.com/open-coap/java-coap)
  * Copyright (C) 2011-2021 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/coap-core/src/testFixtures/java/com/mbed/coap/utils/CoapPacketAssertion.java
+++ b/coap-core/src/testFixtures/java/com/mbed/coap/utils/CoapPacketAssertion.java
@@ -34,7 +34,7 @@ public class CoapPacketAssertion {
         assertEquals(cp1.headers().getUriPath(), cp2.headers().getUriPath());
         assertEquals(cp1.headers().getUriAuthority(), cp2.headers().getUriAuthority());
         assertEquals(cp1.headers().getUriHost(), cp2.headers().getUriHost());
-        assertEquals(cp1.headers().getUriQuery(), cp2.headers().getUriQuery());
+        assertEquals(cp1.headers().getUriQueryList(), cp2.headers().getUriQueryList());
         assertEquals(cp1.headers().getLocationPath(), cp2.headers().getLocationPath());
         assertEquals(cp1.headers().getLocationQuery(), cp2.headers().getLocationQuery());
 

--- a/coap-core/src/testFixtures/java/protocolTests/utils/CoapPacketBuilder.java
+++ b/coap-core/src/testFixtures/java/protocolTests/utils/CoapPacketBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 java-coap contributors (https://github.com/open-coap/java-coap)
+ * Copyright (C) 2022-2026 java-coap contributors (https://github.com/open-coap/java-coap)
  * Copyright (C) 2011-2021 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/coap-core/src/testFixtures/java/protocolTests/utils/CoapPacketBuilder.java
+++ b/coap-core/src/testFixtures/java/protocolTests/utils/CoapPacketBuilder.java
@@ -25,6 +25,7 @@ import com.mbed.coap.packet.Method;
 import com.mbed.coap.packet.Opaque;
 import com.mbed.coap.transport.TransportContext;
 import java.net.InetSocketAddress;
+import java.util.Arrays;
 
 
 public class CoapPacketBuilder {
@@ -94,7 +95,7 @@ public class CoapPacketBuilder {
     }
 
     public CoapPacketBuilder uriQuery(String uriQuery) {
-        coapPacket.headers().setUriQuery(uriQuery);
+        coapPacket.headers().setUriQueryList(Arrays.asList(uriQuery.split("&")));
         return this;
     }
 


### PR DESCRIPTION
## Problem

CoAP carries each query parameter as its own repeatable Uri-Query option (RFC 7252 §5.10). The `&` separator is a URI convention and never appears on the wire - but `HeaderOptions` stored the options joined into one `String`, so it was lossy in both directions:

```java
options.setUriQuery("filter=a&b");   // caller means ONE option
options.getUriQueryList();           // was: ["filter=a", "b"]

```

A value containing `&` couldn't be expressed or round-tripped. `getUriQueryMap()` was derived from that joined string, so it inherited the ambiguity and truncated everything before the first `?`.


## Changes


Storage becomes `List<String>`, one entry per option.


- **New:** `getUriQueryList()`, `setUriQueryList(List|String...)`, `addUriQuery(String)` - lossless, keeps boundaries, repeats and order.

- **New:** `getUriQueryEncoded()` - percent-encoded per RFC 7252 §6.5, for building a URI. Also `DataConvertingUtility.percentEncodeUriQueryOption(String)` for a single option.

- **New:** `CoapOptionsBuilder.queries(List)` / `queries(String...)`.

- **Deprecated:** `getUriQuery()`, `setUriQuery(String)`, `CoapOptionsBuilder.query(String)` - behaviour preserved.

- **Fixed:** serialisation dropped a leading empty Uri-Query option.


## Compatibility

Nothing removed. Two visible changes:

- `query(name, value)` no longer rejects `=`, `&` or `?` **in the value** - each value has its own option, so they aren't separators. The name is still validated.

- `getUriQueryMap()` no longer discards content before a `?`.


Note `getUriQueryEncoded()` implements §6.5, which leaves `+` and `=` literal - it is **not** `application/x-www-form-urlencoded`.