### PR TITLE
fix(coap-core): validate Size1 before allocating block-wise buffer

### DIFF
--- a/coap-core/src/main/java/com/mbed/coap/server/block/BlockWiseIncomingFilter.java
+++ b/coap-core/src/main/java/com/mbed/coap/server/block/BlockWiseIncomingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 java-coap contributors (https://github.com/open-coap/java-coap)
+ * Copyright (C) 2022-2026 java-coap contributors (https://github.com/open-coap/java-coap)
  * Copyright (C) 2011-2021 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -69,7 +69,8 @@ public class BlockWiseIncomingFilter implements Filter.SimpleFilter<CoapRequest,
                 LOGGER.warn("[{}] Mismatch request-tag: {}", request.getPeerAddress(), request.options().getRequestTag());
                 throw new CoapCodeException(Code.C408_REQUEST_ENTITY_INCOMPLETE, "Mismatch request-tag");
             } else if (blockRequest == null) {
-                //start new block-wise transaction
+                //start new block-wise transaction, reject a declared size before allocating for it
+                BlockWiseIncomingTransaction.validateSize1(request, maxIncomingBlockTransferSize);
                 blockRequest = new BlockWiseIncomingTransaction(request, maxIncomingBlockTransferSize, capabilities.getOrDefault(request.getPeerAddress()));
                 blockReqMap.put(blockRequestId, blockRequest);
             }

--- a/coap-core/src/main/java/com/mbed/coap/server/block/BlockWiseIncomingTransaction.java
+++ b/coap-core/src/main/java/com/mbed/coap/server/block/BlockWiseIncomingTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 java-coap contributors (https://github.com/open-coap/java-coap)
+ * Copyright (C) 2022-2026 java-coap contributors (https://github.com/open-coap/java-coap)
  * Copyright (C) 2011-2021 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,12 +43,30 @@ class BlockWiseIncomingTransaction {
         this.maxIncomingBlockTransferSize = maxIncomingBlockTransferSize;
         this.csm = csm;
         this.requestTag = request.options().getRequestTag();
-        Integer expectedPayloadSize = request.options().getSize1();
-        BlockOption blockOption = request.options().getBlock1Req();
+        // Never size this buffer from a peer supplied hint, let it grow as blocks actually arrive.
+        this.payload = new ByteArrayOutputStream();
+    }
 
-        int allocationSize = expectedPayloadSize != null ? expectedPayloadSize : blockOption.getSize() * 4;
-
-        this.payload = new ByteArrayOutputStream(allocationSize);
+    /**
+     * Validates peer declared Size1 option. Must be called before anything is allocated for a transfer.
+     *
+     * @param request incoming request
+     * @param maxIncomingBlockTransferSize maximum allowed transfer size
+     * @throws CoapCodeException if Size1 is unrepresentable or larger than allowed
+     */
+    static void validateSize1(CoapRequest request, int maxIncomingBlockTransferSize) throws CoapCodeException {
+        Integer size1 = request.options().getSize1();
+        if (size1 == null) {
+            return;
+        }
+        if (size1 < 0) {
+            LOGGER.warn("Received request with unrepresentable size1 option: {}", request);
+            throw new CoapCodeException(Code.C402_BAD_OPTION, "invalid size1");
+        }
+        if (size1 > maxIncomingBlockTransferSize) {
+            LOGGER.warn("Received request with too large size1 option: {}", request);
+            throw new CoapRequestEntityTooLarge(maxIncomingBlockTransferSize, "Entity too large");
+        }
     }
 
     void appendBlock(CoapRequest request) throws CoapCodeException {
@@ -118,9 +136,6 @@ class BlockWiseIncomingTransaction {
             throw new CoapCodeException(Code.C400_BAD_REQUEST, "last block size mismatch");
         }
 
-        if (request.options().getSize1() != null && isTooBigPayloadSize(request.options().getSize1())) {
-            LOGGER.warn("Received request with too large size1 option: " + request);
-            throw new CoapRequestEntityTooLarge(maxIncomingBlockTransferSize, "Entity too large");
-        }
+        validateSize1(request, maxIncomingBlockTransferSize);
     }
 }

--- a/coap-core/src/test/java/com/mbed/coap/server/block/BlockWiseIncomingTransactionTest.java
+++ b/coap-core/src/test/java/com/mbed/coap/server/block/BlockWiseIncomingTransactionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 java-coap contributors (https://github.com/open-coap/java-coap)
+ * Copyright (C) 2022-2026 java-coap contributors (https://github.com/open-coap/java-coap)
  * Copyright (C) 2011-2021 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,6 +22,7 @@ import static com.mbed.coap.packet.BlockSize.S_256;
 import static com.mbed.coap.packet.BlockSize.S_512;
 import static com.mbed.coap.packet.CoapRequest.get;
 import static com.mbed.coap.packet.CoapRequest.put;
+import static com.mbed.coap.server.block.BlockWiseIncomingTransaction.validateSize1;
 import static com.mbed.coap.utils.Bytes.opaqueOfSize;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -167,6 +168,26 @@ public class BlockWiseIncomingTransactionTest {
         assertThatThrownBy(() ->
                 bwReq.appendBlock(put("/").block1Req(8, S_1024_BERT, false).payload(opaqueOfSize(2000)).to(LOCAL_5683))
         ).isExactlyInstanceOf(CoapRequestEntityTooLarge.class);
+    }
+
+    @Test
+    public void should_reject_too_large_size1_before_a_transaction_exists() {
+        assertCodeException(Code.C413_REQUEST_ENTITY_TOO_LARGE, () ->
+                validateSize1(put("/").size1(Integer.MAX_VALUE).block1Req(0, S_512, true).payload(opaqueOfSize(512)).to(LOCAL_5683), 10_000)
+        );
+    }
+
+    @Test
+    public void should_reject_unrepresentable_size1_as_client_error() {
+        assertCodeException(Code.C402_BAD_OPTION, () ->
+                validateSize1(put("/").size1(-1).block1Req(0, S_512, true).payload(opaqueOfSize(512)).to(LOCAL_5683), 10_000)
+        );
+    }
+
+    @Test
+    public void should_accept_absent_and_within_limit_size1() throws Exception {
+        validateSize1(put("/").block1Req(0, S_512, true).payload(opaqueOfSize(512)).to(LOCAL_5683), 10_000);
+        validateSize1(put("/").size1(10_000).block1Req(0, S_512, true).payload(opaqueOfSize(512)).to(LOCAL_5683), 10_000);
     }
 
     @Test

--- a/coap-core/src/test/java/protocolTests/Block1Size1LimitTest.java
+++ b/coap-core/src/test/java/protocolTests/Block1Size1LimitTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2026 java-coap contributors (https://github.com/open-coap/java-coap)
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package protocolTests;
+
+import static com.mbed.coap.packet.CoapResponse.coapResponse;
+import static com.mbed.coap.transport.udp.DatagramSocketTransport.udp;
+import static com.mbed.coap.utils.Bytes.opaqueOfSize;
+import static com.mbed.coap.utils.Networks.localhost;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import com.mbed.coap.packet.BlockOption;
+import com.mbed.coap.packet.BlockSize;
+import com.mbed.coap.packet.CoapPacket;
+import com.mbed.coap.packet.CoapResponse;
+import com.mbed.coap.packet.CoapSerializer;
+import com.mbed.coap.packet.Code;
+import com.mbed.coap.packet.MessageType;
+import com.mbed.coap.packet.Method;
+import com.mbed.coap.packet.Opaque;
+import com.mbed.coap.server.CoapServer;
+import com.mbed.coap.server.RouterService;
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetSocketAddress;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A peer declared Size1 must never drive an allocation. Both cases below are sent over a raw DatagramSocket, so that
+ * nothing on the client side normalises the option before it reaches the server.
+ */
+public class Block1Size1LimitTest {
+
+    private static final int DEFAULT_MAX_TRANSFER_SIZE = 10_000_000;
+
+    private CoapServer server;
+    private InetSocketAddress serverAddress;
+    private DatagramSocket socket;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        server = CoapServer.builder()
+                .transport(udp())
+                .route(RouterService.builder()
+                        .get("/test/1", __ -> CoapResponse.ok("alive").toFuture())
+                        .put("/test/1", __ -> coapResponse(Code.C204_CHANGED).toFuture())
+                )
+                .build();
+        server.start();
+        serverAddress = localhost(server.getLocalSocketAddress().getPort());
+
+        socket = new DatagramSocket();
+        socket.setSoTimeout(3000);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        socket.close();
+        server.stop();
+    }
+
+    @Test
+    public void shouldRejectTooLargeSize1WithoutAllocatingForIt() throws Exception {
+        assertEquals(Code.C205_CONTENT, exchange(probe(1)).getCode());
+
+        // a single datagram declaring a 2 GB upload
+        CoapPacket resp = exchange(firstBlock(2, Integer.MAX_VALUE));
+
+        assertEquals(Code.C413_REQUEST_ENTITY_TOO_LARGE, resp.getCode());
+        assertEquals(DEFAULT_MAX_TRANSFER_SIZE, resp.headers().getSize1().intValue());
+
+        // the packet must not have taken the receive loop down with it
+        assertEquals(Code.C205_CONTENT, exchange(probe(3)).getCode());
+    }
+
+    @Test
+    public void shouldRejectUnrepresentableSize1AsClientError() throws Exception {
+        CoapPacket resp = exchange(withRawNegativeSize1(firstBlock(1, Integer.MAX_VALUE)));
+
+        assertEquals(Code.C402_BAD_OPTION, resp.getCode());
+        assertEquals(Code.C205_CONTENT, exchange(probe(2)).getCode());
+    }
+
+    private CoapPacket probe(int messageId) {
+        CoapPacket packet = new CoapPacket(Method.GET, MessageType.Confirmable, "/test/1", serverAddress);
+        packet.setMessageId(messageId);
+        packet.setToken(Opaque.decodeHex("0102"));
+        return packet;
+    }
+
+    private CoapPacket firstBlock(int messageId, int size1) {
+        CoapPacket packet = new CoapPacket(Method.PUT, MessageType.Confirmable, "/test/1", serverAddress);
+        packet.setMessageId(messageId);
+        packet.setToken(Opaque.decodeHex("aabb"));
+        packet.headers().setSize1(size1);
+        packet.headers().setBlock1Req(new BlockOption(0, BlockSize.S_16, true));
+        packet.setPayload(opaqueOfSize(16));
+        return packet;
+    }
+
+    /**
+     * Size1 is read with Opaque.toInt(), which takes at most four bytes, while the typed setter would encode -1 as
+     * eight bytes and be rejected already while parsing. So serialize 0x7FFFFFFF and patch its leading byte, to put
+     * the raw four bytes FF FF FF FF on the wire.
+     */
+    private static byte[] withRawNegativeSize1(CoapPacket packet) {
+        byte[] raw = CoapSerializer.serialize(packet);
+        for (int i = 0; i < raw.length - 3; i++) {
+            if (raw[i] == 0x7F && raw[i + 1] == -1 && raw[i + 2] == -1 && raw[i + 3] == -1) {
+                raw[i] = -1;
+                return raw;
+            }
+        }
+        throw new IllegalStateException("Size1 = 0x7FFFFFFF not found in serialized packet");
+    }
+
+    private CoapPacket exchange(CoapPacket request) throws Exception {
+        return exchange(CoapSerializer.serialize(request));
+    }
+
+    private CoapPacket exchange(byte[] request) throws Exception {
+        socket.send(new DatagramPacket(request, request.length, serverAddress));
+
+        DatagramPacket reply = new DatagramPacket(new byte[1024], 1024);
+        socket.receive(reply);
+        return CoapSerializer.deserialize(serverAddress, reply.getData(), reply.getLength());
+    }
+}


### PR DESCRIPTION
Reject an oversized or unrepresentable Size1 option before any buffer is allocated, and stop deriving the block-wise assembly buffer size from a peer-supplied value.
