### PR TITLE
fix(core): drop messages with control characters in text options

### DIFF
--- a/coap-core/src/main/java/com/mbed/coap/packet/BasicHeaderOptions.java
+++ b/coap-core/src/main/java/com/mbed/coap/packet/BasicHeaderOptions.java
@@ -802,6 +802,10 @@ public class BasicHeaderOptions {
             headerOptNum += delta;
             Opaque headerOptData = Opaque.read(is, len);
             availableInternal -= len;
+            if (isTextOption(headerOptNum) && headerOptData.hasControlChars()) {
+                // deliberately without the value itself, it lands in a log
+                throw new CoapMessageFormatException("Control character in option: " + headerOptNum);
+            }
             put(headerOptNum, headerOptData);
         }
         if (availableInternal < 0) {
@@ -809,6 +813,16 @@ public class BasicHeaderOptions {
         }
         return availableInternal;
 
+    }
+
+    boolean isTextOption(int optionNumber) {
+        return optionNumber == URI_HOST
+                || optionNumber == URI_PATH
+                || optionNumber == URI_QUERY
+                || optionNumber == LOCATION_PATH
+                || optionNumber == LOCATION_QUERY
+                || optionNumber == PROXY_URI
+                || optionNumber == PROXY_SCHEME;
     }
 
     public void duplicate(BasicHeaderOptions opts) {

--- a/coap-core/src/main/java/com/mbed/coap/packet/HeaderOptions.java
+++ b/coap-core/src/main/java/com/mbed/coap/packet/HeaderOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 java-coap contributors (https://github.com/open-coap/java-coap)
+ * Copyright (C) 2022-2026 java-coap contributors (https://github.com/open-coap/java-coap)
  * Copyright (C) 2011-2021 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -141,6 +141,11 @@ public class HeaderOptions extends BasicHeaderOptions {
             sb.append(" Corr-tag:").append(correlationTag);
         }
 
+    }
+
+    @Override
+    boolean isTextOption(int optionNumber) {
+        return optionNumber == OPEN_COAP_CORRELATION_TAG || super.isTextOption(optionNumber);
     }
 
     /**

--- a/coap-core/src/main/java/com/mbed/coap/packet/Opaque.java
+++ b/coap-core/src/main/java/com/mbed/coap/packet/Opaque.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 java-coap contributors (https://github.com/open-coap/java-coap)
+ * Copyright (C) 2022-2026 java-coap contributors (https://github.com/open-coap/java-coap)
  * Copyright (C) 2011-2021 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -172,6 +172,28 @@ public final class Opaque {
 
     public String toUtf8String() {
         return new String(data, CoapConstants.DEFAULT_CHARSET);
+    }
+
+    /**
+     * Tells whether the text of this value holds a control character.
+     *
+     * @return true when {@link #toUtf8String()} would hold at least one ISO control character
+     */
+    public boolean hasControlChars() {
+        for (int i = 0; i < data.length; i++) {
+            int chr = data[i] & 0xFF;
+            if (chr <= 0x1F || chr == 0x7F) {
+                return true;
+            }
+            if (chr == 0xC2 && i + 1 < data.length && isC1Control(data[i + 1] & 0xFF)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isC1Control(int continuationChr) {
+        return continuationChr >= 0x80 && continuationChr <= 0x9F;
     }
 
     public boolean isEmpty() {

--- a/coap-core/src/test/java/com/mbed/coap/packet/CoapPacketTest.java
+++ b/coap-core/src/test/java/com/mbed/coap/packet/CoapPacketTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 java-coap contributors (https://github.com/open-coap/java-coap)
+ * Copyright (C) 2022-2026 java-coap contributors (https://github.com/open-coap/java-coap)
  * Copyright (C) 2011-2021 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,6 +22,7 @@ import static com.mbed.coap.packet.CoapResponse.ok;
 import static com.mbed.coap.packet.CoapSerializer.deserialize;
 import static com.mbed.coap.packet.CoapSerializer.serialize;
 import static com.mbed.coap.utils.CoapPacketAssertion.assertSimilar;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -37,6 +38,7 @@ import static protocolTests.utils.CoapPacketBuilder.LOCAL_1_5683;
 import static protocolTests.utils.CoapPacketBuilder.LOCAL_5683;
 import static protocolTests.utils.CoapPacketBuilder.newCoapPacket;
 import com.mbed.coap.exception.CoapException;
+import com.mbed.coap.exception.CoapMessageFormatException;
 import com.mbed.coap.linkformat.LinkFormat;
 import com.mbed.coap.linkformat.LinkFormatBuilder;
 import com.mbed.coap.transport.TransportContext;
@@ -76,6 +78,54 @@ public class CoapPacketTest {
 
         lf = LinkFormatBuilder.parseList(linkFormatString);
         assertEquals(4, lf.length);
+    }
+
+    @Test
+    public void shouldFailToDeserializeControlCharacterInUriPath() {
+        // a single Uri-Path option value carrying a forged log entry
+        byte[] raw = rawPacketWithOption(BasicHeaderOptions.URI_PATH, "test\r\n11:11:11 INFO -- CON DELETE URI:/admin/wipe");
+
+        assertThatThrownBy(() -> deserialize(null, new ByteArrayInputStream(raw)))
+                .isInstanceOf(CoapMessageFormatException.class)
+                .hasMessage("Control character in option: 11");
+    }
+
+    @Test
+    public void shouldFailToDeserializeControlCharacterInTextOptions() {
+        assertThatThrownBy(() -> deserialize(null, new ByteArrayInputStream(rawPacketWithOption(BasicHeaderOptions.URI_PATH, "cfg\u0000.bak"))))
+                .isInstanceOf(CoapMessageFormatException.class);
+        assertThatThrownBy(() -> deserialize(null, new ByteArrayInputStream(rawPacketWithOption(BasicHeaderOptions.URI_QUERY, "a=\u001b[31m"))))
+                .isInstanceOf(CoapMessageFormatException.class);
+        assertThatThrownBy(() -> deserialize(null, new ByteArrayInputStream(rawPacketWithOption(BasicHeaderOptions.URI_HOST, "host\u0085"))))
+                .isInstanceOf(CoapMessageFormatException.class);
+    }
+
+    @Test
+    public void shouldDeserializeNonAsciiUriPath() throws CoapException {
+        byte[] raw = rawPacketWithOption(BasicHeaderOptions.URI_PATH, "temperatura/wnętrze");
+
+        CoapPacket cp = deserialize(null, new ByteArrayInputStream(raw));
+
+        assertEquals("/temperatura/wnętrze", cp.headers().getUriPath());
+    }
+
+    @Test
+    public void shouldDeserializeControlCharactersInOpaqueOptionAndPayload() throws CoapException {
+        CoapPacket cp = new CoapPacket(Method.PUT, MessageType.Confirmable, "/test", null);
+        cp.headers().setEtag(Opaque.ofBytes(0x00, 0x0d, 0x0a));
+        cp.setPayload("first\r\nsecond");
+
+        CoapPacket cp2 = deserialize(null, new ByteArrayInputStream(serialize(cp)));
+
+        // not text options, arbitrary bytes are legal there
+        assertEquals(Opaque.ofBytes(0x00, 0x0d, 0x0a), cp2.headers().getEtag());
+        assertEquals("first\r\nsecond", cp2.getPayloadString());
+    }
+
+    private static byte[] rawPacketWithOption(int optionNumber, String value) {
+        CoapPacket cp = new CoapPacket(Method.GET, MessageType.Confirmable, null, null);
+        cp.headers().put(optionNumber, Opaque.of(value));
+        return serialize(cp);
     }
 
     @Test

--- a/coap-core/src/test/java/com/mbed/coap/packet/OpaqueTest.java
+++ b/coap-core/src/test/java/com/mbed/coap/packet/OpaqueTest.java
@@ -56,6 +56,8 @@ public class OpaqueTest {
         // replacement character, which is not a control one
         assertFalse(Opaque.ofBytes(0x85).hasControlChars());
         assertFalse(Opaque.ofBytes(0x61, 0xc2).hasControlChars());
+        // 0xc2 followed by something that is not a continuation byte, same story
+        assertFalse(Opaque.ofBytes(0xc2, 0x41).hasControlChars());
     }
 
     @Test

--- a/coap-core/src/test/java/com/mbed/coap/packet/OpaqueTest.java
+++ b/coap-core/src/test/java/com/mbed/coap/packet/OpaqueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 java-coap contributors (https://github.com/open-coap/java-coap)
+ * Copyright (C) 2022-2026 java-coap contributors (https://github.com/open-coap/java-coap)
  * Copyright (C) 2011-2021 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,6 +35,27 @@ public class OpaqueTest {
     public void stringConverting() {
         assertEquals("", Opaque.EMPTY.toUtf8String());
         assertEquals("dupa", Opaque.of("dupa").toUtf8String());
+    }
+
+    @Test
+    public void controlCharsDetecting() {
+        assertFalse(Opaque.EMPTY.hasControlChars());
+        assertFalse(Opaque.of("/test/1").hasControlChars());
+        // valid multi-byte utf-8 is not a control character
+        assertFalse(Opaque.of("temperatura/wnętrze/22°C").hasControlChars());
+
+        assertTrue(Opaque.of("test\r\n11:11:11 INFO -- forged").hasControlChars());
+        assertTrue(Opaque.of("cfg\u0000.bak").hasControlChars());
+        assertTrue(Opaque.of("a\tb").hasControlChars());
+        assertTrue(Opaque.of("\u001b[31mred").hasControlChars());
+        assertTrue(Opaque.of("del\u007f").hasControlChars());
+        // C1, arriving as a two byte utf-8 sequence
+        assertTrue(Opaque.ofBytes(0xc2, 0x85).hasControlChars());
+
+        // malformed utf-8: a lone continuation byte and a truncated sequence decode to a
+        // replacement character, which is not a control one
+        assertFalse(Opaque.ofBytes(0x85).hasControlChars());
+        assertFalse(Opaque.ofBytes(0x61, 0xc2).hasControlChars());
     }
 
     @Test


### PR DESCRIPTION
Uri-Path and other peer controlled option values were rendered the way they arrived, so a CR/LF inside a single option value could forge a complete and syntactically valid log entry, attributing a request to another peer (CWE-117).

Option values of format 'string' are Net-Unicode (RFC 7252 section 3.2, RFC 5198), which leaves no room for control characters, so the parse path now rejects them and the transport discards the message without a response. Opaque options and the payload carry arbitrary bytes by definition and are not checked.

Rendering stays verbatim. Escaping untrusted text belongs to the application's logging configuration, where one rule covers every source of it, this library included: a payload is logged as text, and so is whatever the application logs itself. README says so and the test logback configuration ships a pattern that does it.

Behaviour change: a peer that puts a control character into a text option now gets no response instead of being served.